### PR TITLE
Rename Close to Sync and add an interface.

### DIFF
--- a/Syncer.go
+++ b/Syncer.go
@@ -1,0 +1,5 @@
+package sivafs
+
+type Syncer interface {
+	Sync() error
+}

--- a/filesystem.go
+++ b/filesystem.go
@@ -218,7 +218,7 @@ func (sfs *sivaFS) TempFile(dir string, prefix string) (billy.File, error) {
 	return nil, billy.ErrNotSupported
 }
 
-func (sfs *sivaFS) Close() error {
+func (sfs *sivaFS) Sync() error {
 	return sfs.ensureClosed()
 }
 

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -46,29 +46,37 @@ func (s *SpecificFilesystemSuite) SetUpTest(c *C) {
 	s.tmpDir = c.MkDir()
 }
 
-func (s *SpecificFilesystemSuite) TestOpenClose(c *C) {
+func (s *SpecificFilesystemSuite) TestSync(c *C) {
 	osFs := osfs.New(s.tmpDir)
 
 	fs := New(osFs, "test.siva")
 	c.Assert(fs, NotNil)
 
-	fsCloser, ok := fs.(io.Closer)
+	fsSync, ok := fs.(Syncer)
 	c.Assert(ok, Equals, true)
 
-	err := fsCloser.Close()
+	err := fsSync.Sync()
 	c.Assert(err, IsNil)
 
 	fs = New(osFs, "test.siva")
 	c.Assert(fs, NotNil)
 
-	_, err = fs.Create("testOne.txt")
+	f1, err := fs.Create("testOne.txt")
 	c.Assert(err, IsNil)
 
-	fsCloser, ok = fs.(io.Closer)
+	fsSync, ok = fs.(Syncer)
 	c.Assert(ok, Equals, true)
 
-	err = fsCloser.Close()
+	err = fsSync.Sync()
 	c.Assert(err, IsNil)
+
+	n, err := f1.Write([]byte("TEST"))
+	c.Assert(err, NotNil)
+	c.Assert(n, Equals, 0)
+
+	f2, err := fs.Open("testOne.txt")
+	c.Assert(err, IsNil)
+	c.Assert(f2, NotNil)
 }
 
 func (s *SpecificFilesystemSuite) TestOpenFileNotSupported(c *C) {


### PR DESCRIPTION
Because Close is not the correct name for this method, we rename it to Sync, because is possible to open and create more files after a Sync action. Also we added more tests checking this.