### PR TITLE
added Symlink and Readlink, not supported methods

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -218,6 +218,14 @@ func (sfs *sivaFS) TempFile(dir string, prefix string) (billy.File, error) {
 	return nil, billy.ErrNotSupported
 }
 
+func (sfs *sivaFS) Symlink(target, link string) error {
+	return billy.ErrNotSupported
+}
+
+func (sfs *sivaFS) Readlink(link string) (string, error) {
+	return "", billy.ErrNotSupported
+}
+
 func (sfs *sivaFS) Sync() error {
 	return sfs.ensureClosed()
 }


### PR DESCRIPTION
In order to not break the compatibility of this package with future releases of go-billy, this PR adds two new methods to the interface: `Readlink` and `Symlink` both returning `billy.ErrNotSupported`

https://github.com/src-d/go-billy/pull/32