### PR TITLE
Add Truncate functionality

### DIFF
--- a/file.go
+++ b/file.go
@@ -121,31 +121,36 @@ func (f *file) Unlock() error {
 func (f *file) Truncate(size int64) error {
 	f.Close()
 
-	tmpF, err := f.fileSystem.Open(f.name)
-	if err != nil {
-		return err
-	}
-
 	buffer := make([]byte, size)
-	_, err = tmpF.Read(buffer)
-	if err != err {
-		tmpF.Close()
 
-		return err
+	if size > 0 {
+		tmpF, err := f.fileSystem.Open(f.name)
+		if err != nil {
+			return err
+		}
+
+		_, err = tmpF.Read(buffer)
+		if err != err {
+			tmpF.Close()
+
+			return err
+		}
+
+		tmpF.Close()
 	}
 
-	tmpF.Close()
-
-	tmpF, err = f.fileSystem.Create(f.name)
+	tmpF, err := f.fileSystem.Create(f.name)
 	if err != nil {
 		return err
 	}
 
-	_, err = tmpF.Write(buffer)
-	if err != nil {
-		tmpF.Close()
+	if size > 0 {
+		_, err = tmpF.Write(buffer)
+		if err != nil {
+			tmpF.Close()
 
-		return err
+			return err
+		}
 	}
 
 	tmpF.Close()

--- a/filesystem.go
+++ b/filesystem.go
@@ -308,7 +308,7 @@ func (fs *sivaFS) createFile(path string, flag int, mode os.FileMode) (billy.Fil
 	}
 
 	defer func() { fs.fileWriteModeOpen = true }()
-	return newFile(path, fs.rw, closeFunc), nil
+	return newFile(path, fs, flag, fs.rw, closeFunc), nil
 }
 
 func (fs *sivaFS) openFile(path string, flag int, mode os.FileMode) (billy.File, error) {
@@ -331,7 +331,7 @@ func (fs *sivaFS) openFile(path string, flag int, mode os.FileMode) (billy.File,
 		return nil, err
 	}
 
-	return openFile(path, sr), nil
+	return openFile(path, fs, flag, sr), nil
 }
 
 func (fs *sivaFS) getIndex() (siva.Index, error) {

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -301,7 +301,46 @@ func (s *BaseSivaFsSuite) TestFileWrite(c *C) {
 }
 
 func (s *BaseSivaFsSuite) TestTruncate(c *C) {
-	c.Skip("Truncate is not supported")
+	c.Skip("Standard test is incompatible. Tested in TestSivaTruncate")
+}
+
+func (s *FilesystemSuite) TestSivaTruncate(c *C) {
+	f, err := s.FS.Create("testTruncate.txt")
+	c.Assert(err, IsNil)
+
+	testString := []byte("1234567890")
+	n, err := f.Write(testString)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, len(testString))
+
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	f, err = s.FS.Open("testTruncate.txt")
+	c.Assert(err, IsNil)
+
+	bytes, err := ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes), Equals, string(testString))
+
+	err = f.Truncate(8)
+	c.Assert(err, IsNil)
+
+	bytes, err = ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes), Equals, string(testString[0:8]))
+
+	err = f.Truncate(15)
+	c.Assert(err, IsNil)
+
+	bytes, err = ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+	newString := append(make([]byte, 0), testString[0:8]...)
+	newString = append(newString, make([]byte, 15-8)...)
+	c.Assert(string(bytes), Equals, string(newString))
+
+	err = f.Close()
+	c.Assert(err, IsNil)
 }
 
 func copyFile(src, dst string) error {


### PR DESCRIPTION
The new file is created with the amount of bytes from the previous
version. The file is closed and opened again several times as siva files
can not be opened in read and write modes at the same time.

The last step opens the file again with the same flags as the original one
and copies the structure.

A new test is added for Truncate as the one implemented in go-billy uses
a file in RDWD mode.
