### PR TITLE
sivafs: implement Capabilities method on temp

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -24,6 +24,10 @@ var (
 	ErrWriteOnlyFile            = errors.New("file is write-only")
 )
 
+const sivaCapabilities = billy.ReadCapability |
+	billy.WriteCapability |
+	billy.SeekCapability
+
 type SivaSync interface {
 	// Sync closes any open files, this method should be called at the end of
 	// program to ensure that all the files are properly closed, otherwise the
@@ -249,9 +253,7 @@ func (fs *sivaFS) Sync() error {
 
 // Capability implements billy.Capable interface.
 func (fs *sivaFS) Capabilities() billy.Capability {
-	return billy.ReadCapability |
-		billy.WriteCapability |
-		billy.SeekCapability
+	return sivaCapabilities
 }
 
 func (fs *sivaFS) ensureOpen() error {
@@ -476,6 +478,11 @@ type temp struct {
 	SivaSync
 
 	defaultDir string
+}
+
+// Capability implements billy.Capable interface.
+func (h *temp) Capabilities() billy.Capability {
+	return sivaCapabilities
 }
 
 func (h *temp) TempFile(dir, prefix string) (billy.File, error) {


### PR DESCRIPTION
Make sure temp always returns the siva capabilities when there's a lasagna of underlying filesystems.