### PR TITLE
travis: update go test versions to 1.11 and 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-    - 1.9.x
+    - 1.11.x
     - 1.10.x
-    - tip
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
Signed-off-by: Javi Fontan <jfontan@gmail.com>