### PR TITLE
fix data races, detected during data-retrieval tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - make dependencies
   - make test-coverage
   - make codecov
+  - make test-race
 
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_BRANCH ?= v1
 CI_PATH ?= .ci
 MAKEFILE := $(CI_PATH)/Makefile.main
+TEST_RACE ?= true
 $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-siva.v1 v1.7.0
 )
+
+go 1.13


### PR DESCRIPTION
```go
=== RUN   TestRepoMetadata
==================
WARNING: DATA RACE
Write at 0x00c0001e67b0 by goroutine 112:
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).ensureClosed()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:388 +0x87
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).Sync()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:328 +0x38
  gopkg.in/src-d/go-billy-siva%2ev4.(*temp).Sync()
      <autogenerated>:1 +0x67
  github.com/src-d/go-borges/siva.(*Storage).sync()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/storage.go:355 +0xa9
  github.com/src-d/go-borges/siva.(*Storage).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/storage.go:326 +0x101
  github.com/src-d/go-borges/siva.(*Repository).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/repository.go:131 +0x1e7
  github.com/src-d/gitcollector/downloader.createRootedRepo()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:281 +0x423
  github.com/src-d/gitcollector/downloader.PrepareRepository()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:207 +0x39b
  github.com/src-d/data-retrieval/worker.(*jobDownload).Process()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/download.go:127 +0xd9b
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:348 +0xee8
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:281 +0x268
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /usr/local/go/src/database/sql/sql.go:800 +0x214
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:272 +0xc2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Previous read at 0x00c0001e67b0 by goroutine 25:
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:251 +0xa1
  gopkg.in/src-d/go-billy.v4/helper/polyfill.(*Polyfill).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/polyfill/polyfill.go:55 +0xb0
  gopkg.in/src-d/go-billy.v4/helper/mount.(*Mount).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/mount/mount.go:127 +0xcb
  gopkg.in/src-d/go-billy.v4/helper/polyfill.(*Polyfill).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/polyfill/polyfill.go:55 +0xb0
  gopkg.in/src-d/go-billy.v4/helper/chroot.(*ChrootHelper).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/chroot/chroot.go:151 +0x115
  gopkg.in/src-d/go-billy-siva%2ev4.(*temp).MkdirAll()
      <autogenerated>:1 +0x82
  github.com/src-d/gitcollector/downloader.recursiveCopy()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:300 +0x108
  github.com/src-d/gitcollector/downloader.createRootedRepo.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:269 +0xb0

Goroutine 112 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:50 +0x223

Goroutine 25 (running) created at:
  github.com/src-d/gitcollector/downloader.createRootedRepo()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:268 +0x20a
  github.com/src-d/gitcollector/downloader.PrepareRepository()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:207 +0x39b
  github.com/src-d/data-retrieval/worker.(*jobDownload).Process()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/download.go:127 +0xd9b
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:348 +0xee8
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:281 +0x268
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /usr/local/go/src/database/sql/sql.go:800 +0x214
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:272 +0xc2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
==================
WARNING: DATA RACE
Write at 0x00c0001e67b8 by goroutine 112:
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).ensureClosed()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:389 +0xaf
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).Sync()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:328 +0x38
  gopkg.in/src-d/go-billy-siva%2ev4.(*temp).Sync()
      <autogenerated>:1 +0x67
  github.com/src-d/go-borges/siva.(*Storage).sync()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/storage.go:355 +0xa9
  github.com/src-d/go-borges/siva.(*Storage).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/storage.go:326 +0x101
  github.com/src-d/go-borges/siva.(*Repository).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/repository.go:131 +0x1e7
  github.com/src-d/gitcollector/downloader.createRootedRepo()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:281 +0x423
  github.com/src-d/gitcollector/downloader.PrepareRepository()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:207 +0x39b
  github.com/src-d/data-retrieval/worker.(*jobDownload).Process()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/download.go:127 +0xd9b
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:348 +0xee8
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:281 +0x268
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /usr/local/go/src/database/sql/sql.go:800 +0x214
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:272 +0xc2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Previous read at 0x00c0001e67b8 by goroutine 25:
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).ensureOpen()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:340 +0x5e
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:246 +0x77
  gopkg.in/src-d/go-billy.v4/helper/polyfill.(*Polyfill).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/polyfill/polyfill.go:55 +0xb0
  gopkg.in/src-d/go-billy.v4/helper/mount.(*Mount).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/mount/mount.go:127 +0xcb
  gopkg.in/src-d/go-billy.v4/helper/polyfill.(*Polyfill).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/polyfill/polyfill.go:55 +0xb0
  gopkg.in/src-d/go-billy.v4/helper/chroot.(*ChrootHelper).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/chroot/chroot.go:151 +0x115
  gopkg.in/src-d/go-billy-siva%2ev4.(*temp).MkdirAll()
      <autogenerated>:1 +0x82
  github.com/src-d/gitcollector/downloader.recursiveCopy()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:300 +0x108
  github.com/src-d/gitcollector/downloader.createRootedRepo.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:269 +0xb0

Goroutine 112 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:50 +0x223

Goroutine 25 (running) created at:
  github.com/src-d/gitcollector/downloader.createRootedRepo()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:268 +0x20a
  github.com/src-d/gitcollector/downloader.PrepareRepository()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:207 +0x39b
  github.com/src-d/data-retrieval/worker.(*jobDownload).Process()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/download.go:127 +0xd9b
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:348 +0xee8
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:281 +0x268
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /usr/local/go/src/database/sql/sql.go:800 +0x214
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:272 +0xc2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
==================
WARNING: DATA RACE
Write at 0x00c0002765a0 by goroutine 25:
  gopkg.in/src-d/go-siva%2ev1.(*Index).ToSafePaths()
      /home/lwsanty/goproj/gopath/pkg/mod/gopkg.in/src-d/go-siva.v1@v1.7.0/index.go:213 +0x11e
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).getIndex()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:460 +0x123
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:258 +0xbd
  gopkg.in/src-d/go-billy.v4/helper/polyfill.(*Polyfill).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/polyfill/polyfill.go:55 +0xb0
  gopkg.in/src-d/go-billy.v4/helper/mount.(*Mount).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/mount/mount.go:127 +0xcb
  gopkg.in/src-d/go-billy.v4/helper/polyfill.(*Polyfill).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/polyfill/polyfill.go:55 +0xb0
  gopkg.in/src-d/go-billy.v4/helper/chroot.(*ChrootHelper).MkdirAll()
      /home/lwsanty/goproj/lwsanty/go-billy/helper/chroot/chroot.go:151 +0x115
  gopkg.in/src-d/go-billy-siva%2ev4.(*temp).MkdirAll()
      <autogenerated>:1 +0x82
  github.com/src-d/gitcollector/downloader.recursiveCopy()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:300 +0x108
  github.com/src-d/gitcollector/downloader.createRootedRepo.func1()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:269 +0xb0

Previous read at 0x00c0002765a0 by goroutine 112:
  gopkg.in/src-d/go-siva%2ev1.(*IndexEntry).WriteTo()
      /home/lwsanty/goproj/gopath/pkg/mod/gopkg.in/src-d/go-siva.v1@v1.7.0/index.go:414 +0x55
  gopkg.in/src-d/go-siva%2ev1.(*Index).WriteTo()
      /home/lwsanty/goproj/gopath/pkg/mod/gopkg.in/src-d/go-siva.v1@v1.7.0/index.go:148 +0x468
  gopkg.in/src-d/go-siva%2ev1.(*writer).Close()
      /home/lwsanty/goproj/gopath/pkg/mod/gopkg.in/src-d/go-siva.v1@v1.7.0/writer.go:105 +0xfa
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).ensureClosed()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:383 +0x1e8
  gopkg.in/src-d/go-billy-siva%2ev4.(*sivaFS).Sync()
      /home/lwsanty/goproj/lwsanty/go-billy-siva/filesystem.go:328 +0x38
  gopkg.in/src-d/go-billy-siva%2ev4.(*temp).Sync()
      <autogenerated>:1 +0x67
  github.com/src-d/go-borges/siva.(*Storage).sync()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/storage.go:355 +0xa9
  github.com/src-d/go-borges/siva.(*Storage).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/storage.go:326 +0x101
  github.com/src-d/go-borges/siva.(*Repository).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/siva/repository.go:131 +0x1e7
  github.com/src-d/gitcollector/downloader.createRootedRepo()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:281 +0x423
  github.com/src-d/gitcollector/downloader.PrepareRepository()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:207 +0x39b
  github.com/src-d/data-retrieval/worker.(*jobDownload).Process()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/download.go:127 +0xd9b
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:348 +0xee8
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:281 +0x268
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /usr/local/go/src/database/sql/sql.go:800 +0x214
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:272 +0xc2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 25 (running) created at:
  github.com/src-d/gitcollector/downloader.createRootedRepo()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:268 +0x20a
  github.com/src-d/gitcollector/downloader.PrepareRepository()
      /home/lwsanty/goproj/lwsanty/gitcollector/downloader/git.go:207 +0x39b
  github.com/src-d/data-retrieval/worker.(*jobDownload).Process()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/download.go:127 +0xd9b
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:348 +0xee8
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:281 +0x268
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /usr/local/go/src/database/sql/sql.go:800 +0x214
  github.com/src-d/data-retrieval/worker.TestRepoMetadata()
      /home/lwsanty/goproj/lwsanty/data-retrieval/worker/worker_test.go:272 +0xc2
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 112 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:50 +0x223
==================
--- FAIL: TestRepoMetadata (63.36s)
    worker_test.go:349: 
                Error Trace:    worker_test.go:349
                Error:          Received unexpected error:
                                context deadline exceeded
                Test:           TestRepoMetadata
    testing.go:853: race detected during execution of test
FAIL
FAIL    github.com/src-d/data-retrieval/worker  132.089s
FAIL
```

Signed-off-by: lwsanty <lwsanty@gmail.com>